### PR TITLE
Fix for "should not call get_instance statically" warning

### DIFF
--- a/code/URLShortener.php
+++ b/code/URLShortener.php
@@ -14,7 +14,7 @@ class URLShortener extends Object {
 	
 	private static $default_class = 'SSURLShortener';
 	
-	private function get_instance() {
+	private static function get_instance() {
 		if(!self::$instance)
 			self::set_url_shortener(self::$default_class);
 		return self::$instance;


### PR DESCRIPTION
Change method to static to fix warning